### PR TITLE
Ignore url replace for the first access

### DIFF
--- a/src/routes/url-sync.jsx
+++ b/src/routes/url-sync.jsx
@@ -8,7 +8,6 @@ export default function UrlSync() {
     navigate(hash, { replace: true });
   }
 
-  // write before useEffect for location
   useEffect(() => {
     if (window.google) {
       google.script.url.getLocation((location) => replace(location.hash));
@@ -20,6 +19,9 @@ export default function UrlSync() {
 
   useEffect(() => {
     if (window.google) {
+      // ignore the first access
+      if (location.pathname === "/" && location.key === "default") return;
+      console.log("location changed", location);
       google.script.history.replace(
         { timestamp: new Date().getTime() },
         null,


### PR DESCRIPTION
This pull request introduces the UrlSync component, designed to synchronize the browser's displayed URL with the current location managed by React Router. The synchronization is achieved using google.script.history.replace to update the URL to match the new location whenever React Router detects a location change.

However, there's a special case we encounter upon the web app's initial access. During this phase, React Router identifies the location change with location.pathname === "/" and location.key === "default". To avoid unnecessary updates and potential disruptions during this initial load, we explicitly ignore this specific scenario in our logic.